### PR TITLE
bugfix: add LogonIdValueTransformation for exact matching in Microsof…

### DIFF
--- a/sigma/pipelines/microsoftxdr/microsoftxdr.py
+++ b/sigma/pipelines/microsoftxdr/microsoftxdr.py
@@ -33,6 +33,7 @@ from .mappings import (
 from .schema import MicrosoftXDRSchema
 from .tables import MICROSOFT_XDR_TABLES
 from .transformations import (
+    LogonIdValueTransformation,
     ParentImageValueTransformation,
     SplitDomainUserTransformation,
     XDRHashesValuesTransformation,
@@ -124,6 +125,12 @@ def _create_replacement_items():
             identifier="microsoft_xdr_hashes_field_values",
             transformation=XDRHashesValuesTransformation(),
             field_name_conditions=[IncludeFieldCondition(["Hashes"])],
+        ),
+        # Transform LogonId values to ensure exact matching (== instead of =~)
+        ProcessingItem(
+            identifier="microsoft_xdr_logonid_value_transform",
+            transformation=LogonIdValueTransformation(),
+            field_name_conditions=[IncludeFieldCondition(["LogonId", "InitiatingProcessLogonId"])],
         ),
         # Processing item to essentially ignore initiated field
         ProcessingItem(

--- a/sigma/pipelines/microsoftxdr/transformations.py
+++ b/sigma/pipelines/microsoftxdr/transformations.py
@@ -2,7 +2,7 @@ from typing import Iterable, Optional, Union
 
 from sigma.processing.transformations.base import DetectionItemTransformation, ValueTransformation
 from sigma.rule import SigmaDetection, SigmaDetectionItem
-from sigma.types import SigmaString, SigmaType
+from sigma.types import SigmaString, SigmaType, SigmaNumber
 
 from ..kusto_common.transformations import BaseHashesValuesTransformation
 
@@ -81,3 +81,28 @@ class XDRHashesValuesTransformation(BaseHashesValuesTransformation):
 
     def __init__(self):
         super().__init__(valid_hash_algos=["MD5", "SHA1", "SHA256"], field_prefix="")
+
+
+class LogonIdValueTransformation(ValueTransformation):
+    """
+    Custom ValueTransformation for LogonId fields to ensure exact string matching.
+    LogonId values like "0x3e7" should use exact equality (==) not case-insensitive (=~).
+    This transformation adds a modifier to mark the value for exact matching.
+    """
+
+    def apply_value(self, field: str, val: SigmaType) -> Optional[Union[SigmaType, Iterable[SigmaType]]]:
+        # Return the value as a SigmaNumber if it's a numeric string or hex value
+        # This forces the backend to use == instead of =~
+        value_str = val.to_plain()
+        
+        # Convert hex strings to decimal for numeric comparison
+        if isinstance(value_str, str) and value_str.lower().startswith("0x"):
+            try:
+                # Convert hex to decimal integer
+                numeric_value = int(value_str, 16)
+                return SigmaNumber(numeric_value)
+            except ValueError:
+                # If conversion fails, return as-is
+                pass
+        
+        return val

--- a/tests/test_pipelines_microsoftxdr.py
+++ b/tests/test_pipelines_microsoftxdr.py
@@ -87,6 +87,34 @@ def test_microsoft_xdr_hashes_values_transformation(xdr_backend):
     assert xdr_backend.convert_rule(SigmaRule.from_yaml(yaml_rule)) == expected_result
 
 
+def test_microsoft_xdr_logonid_transformation(xdr_backend):
+    """Test that LogonId values use exact equality (==) instead of case-insensitive (=~)"""
+    yaml_rule = """
+        title: Elevated System Shell Spawned
+        status: test
+        logsource:
+            category: process_creation
+            product: windows
+        detection:
+            selection_shell:
+                Image|endswith:
+                    - '\\powershell.exe'
+                    - '\\cmd.exe'
+            selection_user:
+                User|contains: 'AUTHORI'
+                LogonId: '0x3e7'
+            condition: all of selection_*
+    """
+    expected_result = [
+        "DeviceProcessEvents\n"
+        '| where (FolderPath endswith "\\\\powershell.exe" or FolderPath endswith "\\\\cmd.exe") and '
+        '(AccountName contains "AUTHORI" and LogonId == 999)'  # 0x3e7 converted to decimal
+    ]
+
+    assert xdr_backend.convert(SigmaCollection.from_yaml(yaml_rule)) == expected_result
+    assert xdr_backend.convert_rule(SigmaRule.from_yaml(yaml_rule)) == expected_result
+
+
 def test_microsoft_xdr_process_creation_simple(xdr_backend):
     yaml_rule = """
         title: Test


### PR DESCRIPTION
…t XDR pipeline
LogonIds are stored as long in Defender Tables, thus the =~ comparison results in an error.
Example 
https://github.com/SigmaHQ/sigma/blob/master/rules-threat-hunting/windows/process_creation/proc_creation_win_susp_elevated_system_shell.yml
