### PR TITLE
Feature: add support for all Sigma correlation rule types

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Rules are supported if either:
 
 #### Correlation Rule Support
 
-This backend supports Sigma [correlation rules](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-correlation-rules-specification.md#correlation-types) of type `Value_*` (e.g., `value_count`). These are translated into KQL queries that aggregate event counts grouped by the specified fields.
+This backend supports Sigma [correlation rules](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-correlation-rules-specification.md#correlation-types) of type `Value_*` (e.g., `value_count`) and `Event_count`. These are translated into KQL queries that aggregate event counts grouped by the specified fields.
 
 ### 🖥️ Commonly Supported Categories
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The **pySigma Kusto Backend** transforms Sigma Rules into queries using [Kusto Q
 - **Pipelines**: Provides `microsoft_xdr_pipeline`, `sentinelasim_pipeline`, and `azure_monitor_pipeline` for query tables and field renames
 - **Output**: Query strings in Kusto Query Language (KQL)
 - **pySigma v1.0.0+**: Fully compatible with pySigma v1.0.0+ using factory pattern for pipeline objects
-- **Correlation Rules**: Supports Sigma correlation rules of type `value_count` and other `Value_*` types
+- **Correlation Rules**: Supports all Sigma correlation rules
 
 ### 🧑‍💻 Maintainer
 
@@ -261,7 +261,20 @@ Rules are supported if either:
 
 #### Correlation Rule Support
 
-This backend supports Sigma [correlation rules](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-correlation-rules-specification.md#correlation-types) of type `Value_*` (e.g., `value_count`) and `Event_count`. These are translated into KQL queries that aggregate event counts grouped by the specified fields.
+This backend supports all Sigma [correlation rules](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-correlation-rules-specification.md#correlation-types):
+
+| Correlation type | KQL aggregation |
+|---|---|
+| `event_count` | `summarize EventCount = count() by bin(<timestamp>, <timespan>)` |
+| `value_count` | `summarize ValueCount = count_distinct(<field>) by bin(<timestamp>, <timespan>)` |
+| `value_avg` | `summarize ValueAvg = avg(<field>) by bin(<timestamp>, <timespan>)` |
+| `value_median` | `summarize ValueMedian = percentile(<field>, 50) by bin(<timestamp>, <timespan>)` |
+| `value_sum` | `summarize ValueSum = sum(<field>) by bin(<timestamp>, <timespan>)` |
+| `value_percentile` | `summarize ValuePercentile = percentile(<field>, <p>) by bin(<timestamp>, <timespan>)` |
+| `temporal` | `summarize TemporalCount = count_distinct(EventType) by bin(<timestamp>, <timespan>)` |
+| `temporal_ordered` | `summarize TemporalCount = count_distinct(EventType), <order_aggs> by bin(<timestamp>, <timespan>)` |
+
+Multi-rule correlations union the referenced sub-queries with `union`. The timestamp field used in `bin()` is set automatically by each pipeline (see [Custom Timestamp Field](#️-custom-timestamp-field) above).
 
 ### 🖥️ Commonly Supported Categories
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The **pySigma Kusto Backend** transforms Sigma Rules into queries using [Kusto Q
 - **Pipelines**: Provides `microsoft_xdr_pipeline`, `sentinelasim_pipeline`, and `azure_monitor_pipeline` for query tables and field renames
 - **Output**: Query strings in Kusto Query Language (KQL)
 - **pySigma v1.0.0+**: Fully compatible with pySigma v1.0.0+ using factory pattern for pipeline objects
+- **Correlation Rules**: Supports Sigma correlation rules of type `value_count` and other `Value_*` types
 
 ### 🧑‍💻 Maintainer
 
@@ -236,6 +237,10 @@ Rules are supported if either:
 - A valid table name is supplied via the `query_table` parameter or YAML pipeline
 - The rule's logsource category is supported and mapped in the pipeline's `mappings.py` file
 - The rule has an `EventID` or `EventCode` field in the `detection` section, and the eventid is present in the pipeline's `eventid_to_table_mappings` dictionary
+
+#### Correlation Rule Support
+
+This backend supports Sigma [correlation rules](https://github.com/SigmaHQ/sigma-specification/blob/main/Sigma_meta_rules.md) of type `Value_*` (e.g., `value_count`). These are translated into KQL queries that aggregate event counts grouped by the specified fields.
 
 ### 🖥️ Commonly Supported Categories
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ transformations:
     val: "TimeGenerated"   # or "Timestamp" for XDR
 ```
 
-If no `timestamp_field` is set by any pipeline, the backend falls back to `TimeStamp`.
+If no `timestamp_field` is set by any pipeline, the backend falls back to `Timestamp`.
 
 ### 🗃️ Custom Table Names (New in 0.3.0) (Beta)
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Rules are supported if either:
 
 #### Correlation Rule Support
 
-This backend supports Sigma [correlation rules](https://github.com/SigmaHQ/sigma-specification/blob/main/Sigma_meta_rules.md) of type `Value_*` (e.g., `value_count`). These are translated into KQL queries that aggregate event counts grouped by the specified fields.
+This backend supports Sigma [correlation rules](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-correlation-rules-specification.md#correlation-types) of type `Value_*` (e.g., `value_count`). These are translated into KQL queries that aggregate event counts grouped by the specified fields.
 
 ### 🖥️ Commonly Supported Categories
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,27 @@ pipeline = microsoft_xdr_pipeline(transform_parent_image=False)
 
 This argument allows fine-tuning of the ParentImage field mapping, which can be crucial for accurate rule conversion in certain scenarios. By default, it follows the behavior of mapping ParentImage to the parent process name, but setting it to `False` allows for mapping to the initiating process name instead.
 
+### ⏱️ Custom Timestamp Field
+
+Correlation rules use `bin(<timestamp_field>, <timespan>)` in their aggregation expressions. The timestamp field name differs depending on the target platform:
+
+| Pipeline | Timestamp field |
+|---|---|
+| `microsoft_xdr` | `Timestamp` |
+| `sentinelasim`, `azure_monitor`, none | `TimeGenerated` |
+
+This is set automatically when using the built-in pipelines. If you write a **custom YAML pipeline**, add a `set_state` transformation to declare the correct field:
+
+```yaml
+transformations:
+  - id: set_timestamp_field
+    type: set_state
+    key: timestamp_field
+    val: "TimeGenerated"   # or "Timestamp" for XDR
+```
+
+If no `timestamp_field` is set by any pipeline, the backend falls back to `TimeStamp`.
+
 ### 🗃️ Custom Table Names (New in 0.3.0) (Beta)
 
 The `query_table` argument allows users to override table mappings and set custom table names.  This is useful for converting Sigma rules where the rule category does not easily map to the default table names.

--- a/sigma/backends/kusto/kusto.py
+++ b/sigma/backends/kusto/kusto.py
@@ -228,6 +228,11 @@ class KustoBackend(TextQueryBackend):
     }
     temporal_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where TemporalCount {op} {count}"}
 
+    # temporal_ordered correlation
+    temporal_ordered_aggregation_expression: ClassVar[Dict[str, str]] = {
+        "default": "| summarize TemporalCount = count_distinct(EventType), {order_aggs} by bin({timestamp}, {timespan}){groupby}"
+    }
+
     # Override methods
 
     #  For numeric values, need == instead of =~
@@ -277,6 +282,66 @@ class KustoBackend(TextQueryBackend):
         }
         op = op_map[rule.condition.op]
         condition = self.temporal_condition_expression[method].format(op=op, count=rule.condition.count)
+
+        return [f"{search}\n{aggregate}\n{condition}"]
+
+    def convert_correlation_temporal_ordered_rule(
+        self, rule: SigmaCorrelationRule, output_format: Optional[str] = None, method: str = "default"
+    ) -> list[str]:
+        """Override for ordered temporal correlation.
+
+        Like the temporal correlation but adds an order check: each referenced rule's
+        sub-query is tagged with both ``EventType`` and a 1-based ``EventOrder`` integer.
+        The summarize step uses ``minif(Timestamp, EventOrder == N)`` to capture the
+        first occurrence of each event type, and the condition appends
+        ``FirstTs1 < FirstTs2 and FirstTs2 < FirstTs3 ...`` so that the events must
+        have appeared in the declared rule order within the time window.
+        """
+        subquery_parts = []
+        n_rules = len(rule.referenced_rules)
+        for idx, rule_ref in enumerate(rule.referenced_rules, start=1):
+            base_rule = rule_ref.rule
+            rule_id = str(base_rule.name or base_rule.id)
+            table = getattr(base_rule, "_kusto_query_table", None)
+            normalization = self.convert_correlation_search_field_normalization_expression(rule.aliases, rule_ref)
+            for query in base_rule.get_conversion_result():
+                full_query = query
+                if normalization:
+                    full_query = f"{full_query}\n{normalization}"
+                if table:
+                    full_query = f"{table}\n| where {full_query}"
+                full_query = f'{full_query}\n| extend EventType = "{rule_id}", EventOrder = {idx}'
+                subquery_parts.append(f"(\n{full_query}\n)")
+
+        search = "union\n" + ",\n".join(subquery_parts)
+
+        groupby = (", " + ", ".join(rule.group_by)) if rule.group_by else ""
+        timespan = self._correlation_timespan_to_kql(rule.timespan)
+        timestamp = self._get_timestamp_field()
+
+        op_map = {
+            SigmaCorrelationConditionOperator.GT: ">",
+            SigmaCorrelationConditionOperator.GTE: ">=",
+            SigmaCorrelationConditionOperator.LT: "<",
+            SigmaCorrelationConditionOperator.LTE: "<=",
+            SigmaCorrelationConditionOperator.EQ: "==",
+        }
+        op = op_map[rule.condition.op]
+
+        # Build per-rule minif aggregations: FirstTs1 = minif(Timestamp, EventOrder == 1), ...
+        order_aggs = ", ".join(f"FirstTs{i} = minif({timestamp}, EventOrder == {i})" for i in range(1, n_rules + 1))
+        aggregate = self.temporal_ordered_aggregation_expression[method].format(
+            order_aggs=order_aggs,
+            timespan=timespan,
+            groupby=groupby,
+            timestamp=timestamp,
+        )
+
+        # Build ordering constraint: FirstTs1 < FirstTs2 and FirstTs2 < FirstTs3 ...
+        order_conditions = " and ".join(f"FirstTs{i} < FirstTs{i + 1}" for i in range(1, n_rules))
+        condition = self.temporal_condition_expression[method].format(op=op, count=rule.condition.count)
+        if order_conditions:
+            condition += f" and {order_conditions}"
 
         return [f"{search}\n{aggregate}\n{condition}"]
 

--- a/sigma/backends/kusto/kusto.py
+++ b/sigma/backends/kusto/kusto.py
@@ -1,4 +1,5 @@
 import re
+from collections import Counter
 from typing import ClassVar, Dict, Optional, Pattern, Tuple, Type, Union
 
 from sigma.conditions import ConditionAND, ConditionFieldEqualsValueExpression, ConditionItem, ConditionNOT, ConditionOR
@@ -250,12 +251,15 @@ class KustoBackend(TextQueryBackend):
         for rule_ref in rule.referenced_rules:
             base_rule = rule_ref.rule
             rule_id = str(base_rule.name or base_rule.id)
-            table = getattr(base_rule, "_kusto_query_table", None)
+            table = self._get_rule_table(base_rule)
             normalization = self.convert_correlation_search_field_normalization_expression(rule.aliases, rule_ref)
+            auto_norm = self._build_groupby_normalization(rule, rule_ref)
             for query in base_rule.get_conversion_result():
                 full_query = query
                 if normalization:
                     full_query = f"{full_query}\n{normalization}"
+                if auto_norm:
+                    full_query = f"{full_query}\n{auto_norm}"
                 if table:
                     full_query = f"{table}\n| where {full_query}"
                 full_query = f'{full_query}\n| extend EventType = "{rule_id}"'
@@ -263,7 +267,9 @@ class KustoBackend(TextQueryBackend):
 
         search = "union\n" + ",\n".join(subquery_parts)
 
-        groupby = (", " + ", ".join(rule.group_by)) if rule.group_by else ""
+        # Resolve group-by field names to the canonical (most-common) KQL column name
+        groupby_fields = self._resolve_groupby_fields(rule)
+        groupby = (", " + ", ".join(groupby_fields)) if groupby_fields else ""
         timespan = self._correlation_timespan_to_kql(rule.timespan)
         timestamp = self._get_timestamp_field()
 
@@ -302,12 +308,15 @@ class KustoBackend(TextQueryBackend):
         for idx, rule_ref in enumerate(rule.referenced_rules, start=1):
             base_rule = rule_ref.rule
             rule_id = str(base_rule.name or base_rule.id)
-            table = getattr(base_rule, "_kusto_query_table", None)
+            table = self._get_rule_table(base_rule)
             normalization = self.convert_correlation_search_field_normalization_expression(rule.aliases, rule_ref)
+            auto_norm = self._build_groupby_normalization(rule, rule_ref)
             for query in base_rule.get_conversion_result():
                 full_query = query
                 if normalization:
                     full_query = f"{full_query}\n{normalization}"
+                if auto_norm:
+                    full_query = f"{full_query}\n{auto_norm}"
                 if table:
                     full_query = f"{table}\n| where {full_query}"
                 full_query = f'{full_query}\n| extend EventType = "{rule_id}", EventOrder = {idx}'
@@ -315,7 +324,8 @@ class KustoBackend(TextQueryBackend):
 
         search = "union\n" + ",\n".join(subquery_parts)
 
-        groupby = (", " + ", ".join(rule.group_by)) if rule.group_by else ""
+        groupby_fields = self._resolve_groupby_fields(rule)
+        groupby = (", " + ", ".join(groupby_fields)) if groupby_fields else ""
         timespan = self._correlation_timespan_to_kql(rule.timespan)
         timestamp = self._get_timestamp_field()
 
@@ -451,7 +461,7 @@ class KustoBackend(TextQueryBackend):
         for rule_ref in rule.referenced_rules:
             base_rule = rule_ref.rule
             queries = base_rule.get_conversion_result()
-            table = getattr(base_rule, "_kusto_query_table", None)
+            table = self._get_rule_table(base_rule)
             normalization = self.convert_correlation_search_field_normalization_expression(rule.aliases, rule_ref)
             for query in queries:
                 full_query = query
@@ -462,6 +472,124 @@ class KustoBackend(TextQueryBackend):
                 subquery_parts.append(f"(\n{full_query}\n)")
 
         return "union\n" + ",\n".join(subquery_parts)
+
+    def _get_rule_table(self, rule) -> Optional[str]:
+        """Return the KQL table name for a base rule.
+
+        Priority:
+        1. ``rule._kusto_query_table`` — set by SetQueryTableStateTransformation (Python pipelines).
+        2. ``rule.custom_attributes['query_table']`` — set via ``set_custom_attribute`` in YAML pipelines.
+        """
+        table = getattr(rule, "_kusto_query_table", None)
+        if table is None:
+            table = getattr(rule, "custom_attributes", {}).get("query_table")
+        return table
+
+    def _resolve_field_for_table(self, sigma_field: str, table: Optional[str]) -> str:
+        """Return the KQL column name for *sigma_field* in the context of *table*.
+
+        Walks the active processing pipeline looking for a DynamicFieldMappingTransformation
+        that carries per-table mappings.  Falls back to generic mappings, then the original
+        Sigma field name when nothing matches.
+        """
+        pipeline = getattr(self, "last_processing_pipeline", None)
+        if pipeline is None:
+            return sigma_field
+        for item in pipeline.items:
+            t = item.transformation
+            fm = getattr(t, "field_mappings", None)
+            if fm is None:
+                continue
+            if table:
+                mapped = fm.table_mappings.get(table, {}).get(sigma_field)
+                if mapped:
+                    return mapped
+            generic = fm.generic_mappings.get(sigma_field)
+            if generic:
+                return generic
+        return sigma_field
+
+    def _reverse_resolve_field(self, kql_field: str, table: Optional[str]) -> Optional[str]:
+        """Reverse-lookup: given a KQL column name and a table, return the original Sigma field name.
+
+        Checks table-specific mappings first, then generic mappings.  Returns None if not found
+        (the field may already be a raw KQL name with no Sigma counterpart).
+        """
+        pipeline = getattr(self, "last_processing_pipeline", None)
+        if pipeline is None:
+            return None
+        for item in pipeline.items:
+            t = item.transformation
+            fm = getattr(t, "field_mappings", None)
+            if fm is None:
+                continue
+            if table:
+                rev = {v: k for k, v in fm.table_mappings.get(table, {}).items()}
+                if kql_field in rev:
+                    return rev[kql_field]
+            rev_generic = {v: k for k, v in fm.generic_mappings.items()}
+            if kql_field in rev_generic:
+                return rev_generic[kql_field]
+        return None
+
+    def _resolve_groupby_fields(self, rule: "SigmaCorrelationRule") -> list:  # type: ignore[name-defined]
+        """Return the list of KQL column names to use in the summarize group-by clause.
+
+        For aliased fields the alias name is used as-is.  For un-aliased fields we pick the
+        most-common KQL mapped name across all referenced rules so the name matches what
+        _build_groupby_normalization emits.
+        """
+        if not rule.group_by:
+            return []
+        aliased_fields = {alias.alias for alias in rule.aliases}
+        result = []
+        for kql_field in rule.group_by:
+            if kql_field in aliased_fields:
+                result.append(kql_field)
+                continue
+            # kql_field is already pipeline-mapped; reverse to sigma, then re-resolve per table
+            first_table = self._get_rule_table(rule.referenced_rules[0].rule) if rule.referenced_rules else None
+            sigma_field = self._reverse_resolve_field(kql_field, first_table) or kql_field
+            mapped_names = [
+                self._resolve_field_for_table(sigma_field, self._get_rule_table(rr.rule))
+                for rr in rule.referenced_rules
+            ]
+            canonical = Counter(mapped_names).most_common(1)[0][0]
+            result.append(canonical)
+        return result
+
+    def _build_groupby_normalization(self, rule: "SigmaCorrelationRule", rule_ref) -> str:  # type: ignore[name-defined]
+        """Return ``| extend`` lines that normalize group-by fields whose KQL column name
+        differs across the referenced rules.
+
+        For each un-aliased group-by field (already pipeline-mapped to a KQL name):
+          1. Reverse-resolve to the original Sigma field name.
+          2. Forward-resolve for every referenced rule's table.
+          3. Pick the most-common mapped name as the canonical column name.
+          4. Emit ``| extend <canonical> = <actual>`` for rules where actual != canonical.
+        """
+        if not rule.group_by:
+            return ""
+
+        aliased_fields = {alias.alias for alias in rule.aliases}
+        base_rule = rule_ref.rule
+        table = self._get_rule_table(base_rule)
+
+        extends = []
+        for kql_field in rule.group_by:
+            if kql_field in aliased_fields:
+                continue  # alias machinery handles this already
+            first_table = self._get_rule_table(rule.referenced_rules[0].rule) if rule.referenced_rules else None
+            sigma_field = self._reverse_resolve_field(kql_field, first_table) or kql_field
+            mapped_names = [
+                self._resolve_field_for_table(sigma_field, self._get_rule_table(rr.rule))
+                for rr in rule.referenced_rules
+            ]
+            canonical = Counter(mapped_names).most_common(1)[0][0]
+            my_mapped = self._resolve_field_for_table(sigma_field, table)
+            if my_mapped != canonical:
+                extends.append(f"| extend {canonical} = {my_mapped}")
+        return "\n".join(extends)
 
     def _get_timestamp_field(self) -> str:
         """Return the timestamp field name, preferring any value set by the active pipeline."""

--- a/sigma/backends/kusto/kusto.py
+++ b/sigma/backends/kusto/kusto.py
@@ -175,9 +175,9 @@ class KustoBackend(TextQueryBackend):
     correlation_search_single_rule_expression: ClassVar[str] = "{query}"
 
     # Multiple referenced rules
-    correlation_search_multiple_rules_expression: ClassVar[str] = "union\n{query}"
-    correlation_search_multiple_rules_query_expression: ClassVar[str] = "(\n{query}\n)"
-    correlation_search_multiple_rules_query_expression_joiner: ClassVar[str] = ",\n"
+    correlation_search_multi_rule_expression: ClassVar[str] = "union\n{queries}"
+    correlation_search_multi_rule_query_expression: ClassVar[str] = "(\n{query}\n)"
+    correlation_search_multi_rule_query_expression_joiner: ClassVar[str] = ",\n"
 
     correlation_search_field_normalization_expression: ClassVar[str] = "| extend {alias} = {field}"
     correlation_search_field_normalization_expression_joiner: ClassVar[str] = "\n"
@@ -306,6 +306,31 @@ class KustoBackend(TextQueryBackend):
         # If we have a wildcard in a string, we need to un-escape it
         # See issue #13
         return re.sub(r"\\\*", r"*", converted)
+
+    def convert_correlation_search(self, rule: SigmaCorrelationRule, **kwargs) -> str:
+        """Override to include table names in multi-rule correlation sub-queries.
+        For single-rule correlation, delegates to the base class and lets postprocessing
+        prepend the table. For multi-rule correlation, each sub-query is self-contained
+        with its table name so no top-level prefix is needed.
+        """
+        if len(rule.referenced_rules) <= 1:
+            return super().convert_correlation_search(rule, **kwargs)
+
+        subquery_parts = []
+        for rule_ref in rule.referenced_rules:
+            base_rule = rule_ref.rule
+            queries = base_rule.get_conversion_result()
+            table = getattr(base_rule, "_kusto_query_table", None)
+            normalization = self.convert_correlation_search_field_normalization_expression(rule.aliases, rule_ref)
+            for query in queries:
+                full_query = query
+                if normalization:
+                    full_query = f"{full_query}\n{normalization}"
+                if table:
+                    full_query = f"{table}\n| where {full_query}"
+                subquery_parts.append(f"(\n{full_query}\n)")
+
+        return "union\n" + ",\n".join(subquery_parts)
 
     def _convert_correlation_value_rule(
         self,

--- a/sigma/backends/kusto/kusto.py
+++ b/sigma/backends/kusto/kusto.py
@@ -190,6 +190,27 @@ class KustoBackend(TextQueryBackend):
 
     value_count_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where ValueCount {op} {count}"}
 
+    value_avg_aggregation_expression: ClassVar[Dict[str, str]] = {
+        "default": "| summarize ValueAvg = avg({field}) by bin(TimeGenerated, {timespan}){groupby}"
+    }
+    value_avg_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where ValueAvg {op} {count}"}
+
+    value_median_aggregation_expression: ClassVar[Dict[str, str]] = {
+        "default": "| summarize ValueMedian = percentile({field}, 50) by bin(TimeGenerated, {timespan}){groupby}"
+    }
+
+    value_median_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where ValueMedian {op} {count}"}
+
+    value_sum_aggregation_expression: ClassVar[Dict[str, str]] = {
+        "default": "| summarize ValueSum = sum({field}) by bin(TimeGenerated, {timespan}){groupby}"
+    }
+
+    value_sum_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where ValueSum {op} {count}"}
+
+    value_percentile_aggregation_expression: ClassVar[Dict[str, str]] = {
+        "default": "| summarize ValuePercentile = percentile({field}, {percentile}) by bin(TimeGenerated, {timespan}){groupby}"
+    }
+
     # Override methods
 
     #  For numeric values, need == instead of =~
@@ -286,13 +307,18 @@ class KustoBackend(TextQueryBackend):
         # See issue #13
         return re.sub(r"\\\*", r"*", converted)
 
-    def convert_correlation_value_count_rule(
-        self, rule: SigmaCorrelationRule, output_format: Optional[str] = None, method: str = "default"
+    def _convert_correlation_value_rule(
+        self,
+        rule: SigmaCorrelationRule,
+        aggregation_expressions: Dict[str, str],
+        condition_expressions: Dict[str, str],
+        output_format: Optional[str] = None,
+        method: str = "default",
     ) -> list[str]:
         search = self.convert_correlation_search(rule, output_format=output_format)
         groupby = (", " + ", ".join(rule.group_by)) if rule.group_by else ""
         timespan = self._correlation_timespan_to_kql(rule.timespan)
-        aggregate = self.value_count_aggregation_expression[method].format(
+        aggregate = aggregation_expressions[method].format(
             field=rule.condition.fieldref,
             timespan=timespan,
             groupby=groupby,
@@ -305,8 +331,57 @@ class KustoBackend(TextQueryBackend):
             SigmaCorrelationConditionOperator.EQ: "==",
         }
         op = op_map[rule.condition.op]
-        condition = self.value_count_condition_expression[method].format(op=op, count=rule.condition.count)
+        condition = condition_expressions[method].format(op=op, count=rule.condition.count)
         query = self.default_correlation_query[method].format(search=search, aggregate=aggregate, condition=condition)
+        return [query]
+
+    def convert_correlation_value_count_rule(
+        self, rule: SigmaCorrelationRule, output_format: Optional[str] = None, method: str = "default"
+    ) -> list[str]:
+        return self._convert_correlation_value_rule(
+            rule, self.value_count_aggregation_expression, self.value_count_condition_expression, output_format, method
+        )
+
+    def convert_correlation_value_avg_rule(
+        self, rule: SigmaCorrelationRule, output_format: Optional[str] = None, method: str = "default"
+    ) -> list[str]:
+        return self._convert_correlation_value_rule(
+            rule, self.value_avg_aggregation_expression, self.value_avg_condition_expression, output_format, method
+        )
+
+    def convert_correlation_value_median_rule(
+        self, rule: SigmaCorrelationRule, output_format: Optional[str] = None, method: str = "default"
+    ) -> list[str]:
+        return self._convert_correlation_value_rule(
+            rule,
+            self.value_median_aggregation_expression,
+            self.value_median_condition_expression,
+            output_format,
+            method,
+        )
+
+    def convert_correlation_value_sum_rule(
+        self, rule: SigmaCorrelationRule, output_format: Optional[str] = None, method: str = "default"
+    ) -> list[str]:
+        return self._convert_correlation_value_rule(
+            rule, self.value_sum_aggregation_expression, self.value_sum_condition_expression, output_format, method
+        )
+
+    def convert_correlation_value_percentile_rule(
+        self, rule: SigmaCorrelationRule, output_format: Optional[str] = None, method: str = "default"
+    ) -> list[str]:
+        if not hasattr(rule.condition, "percentile"):
+            raise ValueError("Percentile value must be specified in condition for value_percentile correlation rules.")
+        search = self.convert_correlation_search(rule, output_format=output_format)
+        groupby = (", " + ", ".join(rule.group_by)) if rule.group_by else ""
+        timespan = self._correlation_timespan_to_kql(rule.timespan)
+        aggregate = self.value_percentile_aggregation_expression[method].format(
+            field=rule.condition.fieldref,
+            timespan=timespan,
+            groupby=groupby,
+            percentile=rule.condition.count,
+        )
+        query = self.default_correlation_query[method].format(search=search, aggregate=aggregate, condition=None)
         return [query]
 
     def _correlation_timespan_to_kql(self, timespan: object) -> str:

--- a/sigma/backends/kusto/kusto.py
+++ b/sigma/backends/kusto/kusto.py
@@ -485,35 +485,44 @@ class KustoBackend(TextQueryBackend):
             table = getattr(rule, "custom_attributes", {}).get("query_table")
         return table
 
-    def _resolve_field_for_table(self, sigma_field: str, table: Optional[str]) -> str:
+    def _resolve_field_for_table(self, sigma_field: str, table: Optional[str], base_rule=None) -> str:
         """Return the KQL column name for *sigma_field* in the context of *table*.
 
-        Walks the active processing pipeline looking for a DynamicFieldMappingTransformation
-        that carries per-table mappings.  Falls back to generic mappings, then the original
-        Sigma field name when nothing matches.
+        First checks DynamicFieldMappingTransformation (per-table mappings used by built-in
+        pipelines).  Then falls back to flat FieldMappingTransformation items whose
+        rule_conditions match *base_rule* (used by custom YAML pipelines).  Finally returns
+        the original Sigma field name unchanged.
         """
         pipeline = getattr(self, "last_processing_pipeline", None)
         if pipeline is None:
             return sigma_field
         for item in pipeline.items:
             t = item.transformation
+            # Table-aware mappings (DynamicFieldMappingTransformation from built-in pipelines)
             fm = getattr(t, "field_mappings", None)
-            if fm is None:
+            if fm is not None:
+                if table:
+                    mapped = fm.table_mappings.get(table, {}).get(sigma_field)
+                    if mapped:
+                        return mapped
+                generic = fm.generic_mappings.get(sigma_field)
+                if generic:
+                    return generic
                 continue
-            if table:
-                mapped = fm.table_mappings.get(table, {}).get(sigma_field)
-                if mapped:
-                    return mapped
-            generic = fm.generic_mappings.get(sigma_field)
-            if generic:
-                return generic
+            # Flat mappings (FieldMappingTransformation from custom YAML pipelines)
+            flat = getattr(t, "mapping", None)
+            if flat and sigma_field in flat:
+                if base_rule is None or item.match_rule_conditions(base_rule):
+                    result = flat[sigma_field]
+                    return result[0] if isinstance(result, list) else result
         return sigma_field
 
-    def _reverse_resolve_field(self, kql_field: str, table: Optional[str]) -> Optional[str]:
-        """Reverse-lookup: given a KQL column name and a table, return the original Sigma field name.
+    def _reverse_resolve_field(self, kql_field: str, table: Optional[str], base_rule=None) -> Optional[str]:
+        """Reverse-lookup: given a KQL column name, return the original Sigma field name.
 
-        Checks table-specific mappings first, then generic mappings.  Returns None if not found
-        (the field may already be a raw KQL name with no Sigma counterpart).
+        Checks table-specific mappings first, then generic mappings (built-in pipelines),
+        then flat FieldMappingTransformation items matching *base_rule* (custom pipelines).
+        Returns None if not found (the field may already be a raw KQL name).
         """
         pipeline = getattr(self, "last_processing_pipeline", None)
         if pipeline is None:
@@ -521,15 +530,21 @@ class KustoBackend(TextQueryBackend):
         for item in pipeline.items:
             t = item.transformation
             fm = getattr(t, "field_mappings", None)
-            if fm is None:
+            if fm is not None:
+                if table:
+                    rev = {v: k for k, v in fm.table_mappings.get(table, {}).items()}
+                    if kql_field in rev:
+                        return rev[kql_field]
+                rev_generic = {v: k for k, v in fm.generic_mappings.items()}
+                if kql_field in rev_generic:
+                    return rev_generic[kql_field]
                 continue
-            if table:
-                rev = {v: k for k, v in fm.table_mappings.get(table, {}).items()}
-                if kql_field in rev:
-                    return rev[kql_field]
-            rev_generic = {v: k for k, v in fm.generic_mappings.items()}
-            if kql_field in rev_generic:
-                return rev_generic[kql_field]
+            flat = getattr(t, "mapping", None)
+            if flat:
+                if base_rule is None or item.match_rule_conditions(base_rule):
+                    rev_flat = {v: k for k, v in flat.items() if not isinstance(v, list)}
+                    if kql_field in rev_flat:
+                        return rev_flat[kql_field]
         return None
 
     def _resolve_groupby_fields(self, rule: "SigmaCorrelationRule") -> list:  # type: ignore[name-defined]
@@ -543,15 +558,16 @@ class KustoBackend(TextQueryBackend):
             return []
         aliased_fields = {alias.alias for alias in rule.aliases}
         result = []
+        first_ref = rule.referenced_rules[0] if rule.referenced_rules else None
         for kql_field in rule.group_by:
             if kql_field in aliased_fields:
                 result.append(kql_field)
                 continue
-            # kql_field is already pipeline-mapped; reverse to sigma, then re-resolve per table
-            first_table = self._get_rule_table(rule.referenced_rules[0].rule) if rule.referenced_rules else None
-            sigma_field = self._reverse_resolve_field(kql_field, first_table) or kql_field
+            first_table = self._get_rule_table(first_ref.rule) if first_ref else None
+            first_rule = first_ref.rule if first_ref else None
+            sigma_field = self._reverse_resolve_field(kql_field, first_table, first_rule) or kql_field
             mapped_names = [
-                self._resolve_field_for_table(sigma_field, self._get_rule_table(rr.rule))
+                self._resolve_field_for_table(sigma_field, self._get_rule_table(rr.rule), rr.rule)
                 for rr in rule.referenced_rules
             ]
             canonical = Counter(mapped_names).most_common(1)[0][0]
@@ -564,7 +580,7 @@ class KustoBackend(TextQueryBackend):
 
         For each un-aliased group-by field (already pipeline-mapped to a KQL name):
           1. Reverse-resolve to the original Sigma field name.
-          2. Forward-resolve for every referenced rule's table.
+          2. Forward-resolve per referenced rule's table, using rule conditions for flat mappings.
           3. Pick the most-common mapped name as the canonical column name.
           4. Emit ``| extend <canonical> = <actual>`` for rules where actual != canonical.
         """
@@ -574,19 +590,21 @@ class KustoBackend(TextQueryBackend):
         aliased_fields = {alias.alias for alias in rule.aliases}
         base_rule = rule_ref.rule
         table = self._get_rule_table(base_rule)
+        first_ref = rule.referenced_rules[0] if rule.referenced_rules else None
 
         extends = []
         for kql_field in rule.group_by:
             if kql_field in aliased_fields:
                 continue  # alias machinery handles this already
-            first_table = self._get_rule_table(rule.referenced_rules[0].rule) if rule.referenced_rules else None
-            sigma_field = self._reverse_resolve_field(kql_field, first_table) or kql_field
+            first_table = self._get_rule_table(first_ref.rule) if first_ref else None
+            first_rule = first_ref.rule if first_ref else None
+            sigma_field = self._reverse_resolve_field(kql_field, first_table, first_rule) or kql_field
             mapped_names = [
-                self._resolve_field_for_table(sigma_field, self._get_rule_table(rr.rule))
+                self._resolve_field_for_table(sigma_field, self._get_rule_table(rr.rule), rr.rule)
                 for rr in rule.referenced_rules
             ]
             canonical = Counter(mapped_names).most_common(1)[0][0]
-            my_mapped = self._resolve_field_for_table(sigma_field, table)
+            my_mapped = self._resolve_field_for_table(sigma_field, table, base_rule)
             if my_mapped != canonical:
                 extends.append(f"| extend {canonical} = {my_mapped}")
         return "\n".join(extends)

--- a/sigma/backends/kusto/kusto.py
+++ b/sigma/backends/kusto/kusto.py
@@ -183,33 +183,42 @@ class KustoBackend(TextQueryBackend):
     correlation_search_field_normalization_expression_joiner: ClassVar[str] = "\n"
 
     # value_count correlation
-
     value_count_aggregation_expression: ClassVar[Dict[str, str]] = {
         "default": "| summarize ValueCount = count_distinct({field}) by bin(TimeGenerated, {timespan}){groupby}"
     }
 
     value_count_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where ValueCount {op} {count}"}
 
+    # value_avg correlation
     value_avg_aggregation_expression: ClassVar[Dict[str, str]] = {
         "default": "| summarize ValueAvg = avg({field}) by bin(TimeGenerated, {timespan}){groupby}"
     }
     value_avg_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where ValueAvg {op} {count}"}
 
+    # value_median correlation
     value_median_aggregation_expression: ClassVar[Dict[str, str]] = {
         "default": "| summarize ValueMedian = percentile({field}, 50) by bin(TimeGenerated, {timespan}){groupby}"
     }
 
     value_median_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where ValueMedian {op} {count}"}
 
+    # value_sum correlation
     value_sum_aggregation_expression: ClassVar[Dict[str, str]] = {
         "default": "| summarize ValueSum = sum({field}) by bin(TimeGenerated, {timespan}){groupby}"
     }
 
     value_sum_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where ValueSum {op} {count}"}
 
+    # value_percentile correlation
     value_percentile_aggregation_expression: ClassVar[Dict[str, str]] = {
         "default": "| summarize ValuePercentile = percentile({field}, {percentile}) by bin(TimeGenerated, {timespan}){groupby}"
     }
+
+    # event_count correlation
+    event_count_aggregation_expression: ClassVar[Dict[str, str]] = {
+        "default": "| summarize EventCount = count() by bin(TimeGenerated, {timespan}){groupby}"
+    }
+    event_count_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where EventCount {op} {count}"}
 
     # Override methods
 
@@ -408,6 +417,13 @@ class KustoBackend(TextQueryBackend):
         )
         query = self.default_correlation_query[method].format(search=search, aggregate=aggregate, condition=None)
         return [query]
+
+    def convert_correlation_event_count_rule(
+        self, rule: SigmaCorrelationRule, output_format: Optional[str] = None, method: str = "default"
+    ) -> list[str]:
+        return self._convert_correlation_value_rule(
+            rule, self.event_count_aggregation_expression, self.event_count_condition_expression, output_format, method
+        )
 
     def _correlation_timespan_to_kql(self, timespan: object) -> str:
         """Convert SigmaCorrelationTimespan into valid KQL timespan literal."""

--- a/sigma/backends/kusto/kusto.py
+++ b/sigma/backends/kusto/kusto.py
@@ -1,16 +1,11 @@
 import re
-from typing import ClassVar, Dict, Pattern, Tuple, Type, Union
+from typing import ClassVar, Dict, Optional, Pattern, Tuple, Type, Union
 
-from sigma.conditions import (
-    ConditionAND,
-    ConditionFieldEqualsValueExpression,
-    ConditionItem,
-    ConditionNOT,
-    ConditionOR,
-)
+from sigma.conditions import ConditionAND, ConditionFieldEqualsValueExpression, ConditionItem, ConditionNOT, ConditionOR
 from sigma.conversion.base import TextQueryBackend
 from sigma.conversion.deferred import DeferredQueryExpression
 from sigma.conversion.state import ConversionState
+from sigma.correlations import SigmaCorrelationConditionOperator, SigmaCorrelationRule
 from sigma.types import SigmaCompareExpression, SigmaNumber, SigmaString, SpecialChars
 
 
@@ -161,6 +156,40 @@ class KustoBackend(TextQueryBackend):
     # to use it
     num_eq_token: ClassVar[str] = " == "
 
+    timespan_mapping: ClassVar[Dict[str, str]] = {
+        "s": "s",
+        "m": "min",
+        "h": "h",
+        "d": "d",
+    }
+
+    # Correlation support
+
+    correlation_methods: ClassVar[Dict[str, str]] = {
+        "default": "Summarize with bin() - clock-aligned time buckets",
+    }
+    default_correlation_method: ClassVar[str] = "default"
+
+    default_correlation_query: ClassVar[str] = {"default": "{search}\n{aggregate}\n{condition}"}
+
+    correlation_search_single_rule_expression: ClassVar[str] = "{query}"
+
+    # Multiple referenced rules
+    correlation_search_multiple_rules_expression: ClassVar[str] = "union\n{query}"
+    correlation_search_multiple_rules_query_expression: ClassVar[str] = "(\n{query}\n)"
+    correlation_search_multiple_rules_query_expression_joiner: ClassVar[str] = ",\n"
+
+    correlation_search_field_normalization_expression: ClassVar[str] = "| extend {alias} = {field}"
+    correlation_search_field_normalization_expression_joiner: ClassVar[str] = "\n"
+
+    # value_count correlation
+
+    value_count_aggregation_expression: ClassVar[Dict[str, str]] = {
+        "default": "| summarize ValueCount = count_distinct({field}) by bin(TimeGenerated, {timespan}){groupby}"
+    }
+
+    value_count_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where ValueCount {op} {count}"}
+
     # Override methods
 
     #  For numeric values, need == instead of =~
@@ -256,3 +285,40 @@ class KustoBackend(TextQueryBackend):
         # If we have a wildcard in a string, we need to un-escape it
         # See issue #13
         return re.sub(r"\\\*", r"*", converted)
+
+    def convert_correlation_value_count_rule(
+        self, rule: SigmaCorrelationRule, output_format: Optional[str] = None, method: str = "default"
+    ) -> list[str]:
+        search = self.convert_correlation_search(rule, output_format=output_format)
+        groupby = (", " + ", ".join(rule.group_by)) if rule.group_by else ""
+        timespan = self._correlation_timespan_to_kql(rule.timespan)
+        aggregate = self.value_count_aggregation_expression[method].format(
+            field=rule.condition.fieldref,
+            timespan=timespan,
+            groupby=groupby,
+        )
+        op_map = {
+            SigmaCorrelationConditionOperator.GT: ">",
+            SigmaCorrelationConditionOperator.GTE: ">=",
+            SigmaCorrelationConditionOperator.LT: "<",
+            SigmaCorrelationConditionOperator.LTE: "<=",
+            SigmaCorrelationConditionOperator.EQ: "==",
+        }
+        op = op_map[rule.condition.op]
+        condition = self.value_count_condition_expression[method].format(op=op, count=rule.condition.count)
+        query = self.default_correlation_query[method].format(search=search, aggregate=aggregate, condition=condition)
+        return [query]
+
+    def _correlation_timespan_to_kql(self, timespan: object) -> str:
+        """Convert SigmaCorrelationTimespan into valid KQL timespan literal."""
+        spec = getattr(timespan, "spec", None)
+        if isinstance(spec, str) and spec:
+            return spec
+
+        count = getattr(timespan, "count", None)
+        unit = getattr(timespan, "unit", None)
+        if isinstance(count, int) and count > 0 and isinstance(unit, str):
+            mapped_unit = self.timespan_mapping.get(unit, unit)
+            return f"{count}{mapped_unit}"
+
+        return str(timespan)

--- a/sigma/backends/kusto/kusto.py
+++ b/sigma/backends/kusto/kusto.py
@@ -222,9 +222,64 @@ class KustoBackend(TextQueryBackend):
     }
     event_count_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where EventCount {op} {count}"}
 
+    # temporal correlation
+    temporal_aggregation_expression: ClassVar[Dict[str, str]] = {
+        "default": "| summarize TemporalCount = count_distinct(EventType) by bin({timestamp}, {timespan}){groupby}"
+    }
+    temporal_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where TemporalCount {op} {count}"}
+
     # Override methods
 
     #  For numeric values, need == instead of =~
+    def convert_correlation_temporal_rule(
+        self, rule: SigmaCorrelationRule, output_format: Optional[str] = None, method: str = "default"
+    ) -> list[str]:
+        """Override for temporal correlation.
+
+        Tags each referenced-rule sub-query with its rule ID via ``| extend EventType``,
+        unions them, then counts *distinct* event types per time bucket.  This matches the
+        intended semantics: detect multiple different event types occurring close together
+        in time (e.g. failed logon followed by successful logon from the same source).
+        """
+        subquery_parts = []
+        for rule_ref in rule.referenced_rules:
+            base_rule = rule_ref.rule
+            rule_id = str(base_rule.name or base_rule.id)
+            table = getattr(base_rule, "_kusto_query_table", None)
+            normalization = self.convert_correlation_search_field_normalization_expression(rule.aliases, rule_ref)
+            for query in base_rule.get_conversion_result():
+                full_query = query
+                if normalization:
+                    full_query = f"{full_query}\n{normalization}"
+                if table:
+                    full_query = f"{table}\n| where {full_query}"
+                full_query = f'{full_query}\n| extend EventType = "{rule_id}"'
+                subquery_parts.append(f"(\n{full_query}\n)")
+
+        search = "union\n" + ",\n".join(subquery_parts)
+
+        groupby = (", " + ", ".join(rule.group_by)) if rule.group_by else ""
+        timespan = self._correlation_timespan_to_kql(rule.timespan)
+        timestamp = self._get_timestamp_field()
+
+        aggregate = self.temporal_aggregation_expression[method].format(
+            timespan=timespan,
+            groupby=groupby,
+            timestamp=timestamp,
+        )
+
+        op_map = {
+            SigmaCorrelationConditionOperator.GT: ">",
+            SigmaCorrelationConditionOperator.GTE: ">=",
+            SigmaCorrelationConditionOperator.LT: "<",
+            SigmaCorrelationConditionOperator.LTE: "<=",
+            SigmaCorrelationConditionOperator.EQ: "==",
+        }
+        op = op_map[rule.condition.op]
+        condition = self.temporal_condition_expression[method].format(op=op, count=rule.condition.count)
+
+        return [f"{search}\n{aggregate}\n{condition}"]
+
     def convert_condition_field_eq_val_num(
         self, cond: ConditionFieldEqualsValueExpression, state: ConversionState
     ) -> Union[str, DeferredQueryExpression]:

--- a/sigma/backends/kusto/kusto.py
+++ b/sigma/backends/kusto/kusto.py
@@ -156,6 +156,8 @@ class KustoBackend(TextQueryBackend):
     # to use it
     num_eq_token: ClassVar[str] = " == "
 
+    timestamp_field: ClassVar[str] = "Timestamp"  # Default timestamp field name, can be overridden by pipeline state
+
     timespan_mapping: ClassVar[Dict[str, str]] = {
         "s": "s",
         "m": "min",
@@ -184,39 +186,39 @@ class KustoBackend(TextQueryBackend):
 
     # value_count correlation
     value_count_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "default": "| summarize ValueCount = count_distinct({field}) by bin(TimeGenerated, {timespan}){groupby}"
+        "default": "| summarize ValueCount = count_distinct({field}) by bin({timestamp}, {timespan}){groupby}"
     }
 
     value_count_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where ValueCount {op} {count}"}
 
     # value_avg correlation
     value_avg_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "default": "| summarize ValueAvg = avg({field}) by bin(TimeGenerated, {timespan}){groupby}"
+        "default": "| summarize ValueAvg = avg({field}) by bin({timestamp}, {timespan}){groupby}"
     }
     value_avg_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where ValueAvg {op} {count}"}
 
     # value_median correlation
     value_median_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "default": "| summarize ValueMedian = percentile({field}, 50) by bin(TimeGenerated, {timespan}){groupby}"
+        "default": "| summarize ValueMedian = percentile({field}, 50) by bin({timestamp}, {timespan}){groupby}"
     }
 
     value_median_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where ValueMedian {op} {count}"}
 
     # value_sum correlation
     value_sum_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "default": "| summarize ValueSum = sum({field}) by bin(TimeGenerated, {timespan}){groupby}"
+        "default": "| summarize ValueSum = sum({field}) by bin({timestamp}, {timespan}){groupby}"
     }
 
     value_sum_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where ValueSum {op} {count}"}
 
     # value_percentile correlation
     value_percentile_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "default": "| summarize ValuePercentile = percentile({field}, {percentile}) by bin(TimeGenerated, {timespan}){groupby}"
+        "default": "| summarize ValuePercentile = percentile({field}, {percentile}) by bin({timestamp}, {timespan}){groupby}"
     }
 
     # event_count correlation
     event_count_aggregation_expression: ClassVar[Dict[str, str]] = {
-        "default": "| summarize EventCount = count() by bin(TimeGenerated, {timespan}){groupby}"
+        "default": "| summarize EventCount = count() by bin({timestamp}, {timespan}){groupby}"
     }
     event_count_condition_expression: ClassVar[Dict[str, str]] = {"default": "| where EventCount {op} {count}"}
 
@@ -341,6 +343,13 @@ class KustoBackend(TextQueryBackend):
 
         return "union\n" + ",\n".join(subquery_parts)
 
+    def _get_timestamp_field(self) -> str:
+        """Return the timestamp field name, preferring any value set by the active pipeline."""
+        pipeline = getattr(self, "last_processing_pipeline", None)
+        if pipeline is not None:
+            return pipeline.state.get("timestamp_field", self.timestamp_field)
+        return self.timestamp_field
+
     def _convert_correlation_value_rule(
         self,
         rule: SigmaCorrelationRule,
@@ -356,6 +365,7 @@ class KustoBackend(TextQueryBackend):
             field=rule.condition.fieldref,
             timespan=timespan,
             groupby=groupby,
+            timestamp=self._get_timestamp_field(),
         )
         op_map = {
             SigmaCorrelationConditionOperator.GT: ">",
@@ -414,6 +424,7 @@ class KustoBackend(TextQueryBackend):
             timespan=timespan,
             groupby=groupby,
             percentile=rule.condition.count,
+            timestamp=self._get_timestamp_field(),
         )
         query = self.default_correlation_query[method].format(search=search, aggregate=aggregate, condition=None)
         return [query]

--- a/sigma/pipelines/azuremonitor/azuremonitor.py
+++ b/sigma/pipelines/azuremonitor/azuremonitor.py
@@ -13,6 +13,7 @@ from sigma.processing.transformations import (
     DropDetectionItemTransformation,
     ReplaceStringTransformation,
     RuleFailureTransformation,
+    SetStateTransformation,
 )
 
 from ..kusto_common.errors import InvalidFieldTransformation
@@ -223,6 +224,10 @@ def azure_monitor_pipeline(query_table: Optional[str] = None) -> ProcessingPipel
     """
 
     pipeline_items = [
+        ProcessingItem(
+            identifier="azure_monitor_set_timestamp_field",
+            transformation=SetStateTransformation(key="timestamp_field", val="TimeGenerated"),
+        ),
         ProcessingItem(
             identifier="azure_monitor_set_query_table",
             transformation=SetQueryTableStateTransformation(

--- a/sigma/pipelines/kusto_common/conditions.py
+++ b/sigma/pipelines/kusto_common/conditions.py
@@ -13,4 +13,7 @@ class QueryTableSetCondition(RuleProcessingCondition):
         rule: Union[SigmaRule, SigmaCorrelationRule],
     ) -> bool:
         """Match condition on Sigma rule."""
+        # Multi-rule correlation includes table names inside each sub-query, so skip top-level prepend
+        if isinstance(rule, SigmaCorrelationRule) and len(rule.referenced_rules) > 1:
+            return False
         return self._pipeline.state.get("query_table", None) is not None

--- a/sigma/pipelines/kusto_common/transformations.py
+++ b/sigma/pipelines/kusto_common/transformations.py
@@ -4,9 +4,10 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 from sigma.conditions import ConditionOR
+from sigma.correlations import SigmaCorrelationRule
 from sigma.processing.transformations import FieldMappingTransformation, Transformation
 from sigma.processing.transformations.base import DetectionItemTransformation, ValueTransformation
-from sigma.rule import SigmaDetection, SigmaDetectionItem
+from sigma.rule import SigmaDetection, SigmaDetectionItem, SigmaRule
 from sigma.types import SigmaString, SigmaType
 
 from ..kusto_common.mappings import get_table_from_eventid
@@ -180,7 +181,28 @@ class SetQueryTableStateTransformation(Transformation):
                     self.processing_item_applied(detection.detection_items[i])
                     return r
 
-    def apply(self, rule: "SigmaRule") -> None:  # type: ignore  # noqa: F821
+    def _get_table_name_from_sigma_rule(self, rule: SigmaRule) -> Optional[str]:
+        if rule.logsource.category:
+            return self.category_to_table_mappings.get(rule.logsource.category)
+
+        for section_title, detection in rule.detection.detections.items():
+            # We only want event types from selection sections, not filters
+            if re.match(r"^sel.*", section_title.lower()):
+                if (r := self.apply_detection(detection)) is not None:
+                    return r
+
+        return None
+
+    def _get_table_name_from_correlation_rule(self, rule: SigmaCorrelationRule) -> Optional[str]:
+        for rule_ref in rule.rules:
+            ref_rule = getattr(rule_ref, "rule", None)
+            if isinstance(ref_rule, SigmaRule):
+                if (table_name := self._get_table_name_from_sigma_rule(ref_rule)) is not None:
+                    return table_name
+
+        return None
+
+    def apply(self, rule: Union["SigmaRule", "SigmaCorrelationRule"]) -> None:  # type: ignore  # noqa: F821
         # Init table_name to None, will be set in the following if statements
         table_name = None
         # Set table_name based on the following priority:
@@ -190,18 +212,12 @@ class SetQueryTableStateTransformation(Transformation):
         # 2) If the query_table is already set in the pipeline state, use that value (e.g. set in a previous pipeline, like via YAML in sigma-cli for user-defined query tables)
         elif self._pipeline.state.get("query_table"):
             table_name = self._pipeline.state.get("query_table")
-        # 3) If the rule's logsource category is present in the category_to_table_mappings dictionary, use that value
-        elif rule.logsource.category:
-            category = rule.logsource.category
-            table_name = self.category_to_table_mappings.get(category)
-        # 4) Check if the rule has an EventID, use the table name from the eventid_to_table_mappings dictionary
+        # 3) If this is a correlation rule, derive table from referenced base rules.
+        elif isinstance(rule, SigmaCorrelationRule):
+            table_name = self._get_table_name_from_correlation_rule(rule)
+        # 4) For standard rules, map from category/EventID.
         else:
-            for section_title, detection in rule.detection.detections.items():
-                # We only want event types from selection sections, not filters
-                if re.match(r"^sel.*", section_title.lower()):
-                    if (r := self.apply_detection(detection)) is not None:
-                        table_name = r
-                        break
+            table_name = self._get_table_name_from_sigma_rule(rule)
 
         if table_name:
             if isinstance(table_name, list):

--- a/sigma/pipelines/kusto_common/transformations.py
+++ b/sigma/pipelines/kusto_common/transformations.py
@@ -223,6 +223,9 @@ class SetQueryTableStateTransformation(Transformation):
             if isinstance(table_name, list):
                 table_name = table_name[0]  # Use the first table if it's a list
             self._pipeline.state["query_table"] = table_name
+            # Store table on SigmaRule so multi-rule correlation can look up per-rule table names
+            if isinstance(rule, SigmaRule):
+                rule._kusto_query_table = table_name
             # Mark this processing item as applied so that RuleProcessingItemAppliedCondition works
             self.processing_item_applied(rule)
         else:

--- a/sigma/pipelines/microsoftxdr/mappings.py
+++ b/sigma/pipelines/microsoftxdr/mappings.py
@@ -76,6 +76,7 @@ MICROSOFT_XDR_FIELD_MAPPINGS = MicrosoftXDRFieldMappings(
             "CommandLine": "ProcessCommandLine",
             # CurrentDirectory: ?
             "User": "AccountName",
+            "ComputerName": "DeviceName",
             # LogonGuid: ?
             "LogonId": "LogonId",
             # TerminalSessionId: ?
@@ -108,6 +109,7 @@ MICROSOFT_XDR_FIELD_MAPPINGS = MicrosoftXDRFieldMappings(
             # 'Signature': ?
             # 'SignatureStatus': ?
             "User": "InitiatingProcessAccountName",
+            "ComputerName": "DeviceName",
         },
         "DeviceFileEvents": {  # file_*, Sysmon EventID 11 (create), 23 (delete) -> DeviceFileEvents table
             # 'ProcessGuid': ?,
@@ -116,6 +118,7 @@ MICROSOFT_XDR_FIELD_MAPPINGS = MicrosoftXDRFieldMappings(
             "TargetFilename": "FolderPath",
             # 'CreationUtcTime': 'Timestamp',
             "User": "RequestAccountName",
+            "ComputerName": "DeviceName",
             # 'Hashes': ?,
             "sha1": "SHA1",
             "sha256": "SHA256",
@@ -128,6 +131,7 @@ MICROSOFT_XDR_FIELD_MAPPINGS = MicrosoftXDRFieldMappings(
             "ProcessId": "InitiatingProcessId",
             "Image": "InitiatingProcessFolderPath",
             "User": "InitiatingProcessAccountName",
+            "ComputerName": "DeviceName",
             "Protocol": "Protocol",
             # 'Initiated': ?,
             # 'SourceIsIpv6': ?,
@@ -151,12 +155,14 @@ MICROSOFT_XDR_FIELD_MAPPINGS = MicrosoftXDRFieldMappings(
             # 'NewName': ?
             "Details": "RegistryValueData",
             "User": "InitiatingProcessAccountName",
+            "ComputerName": "DeviceName",
             "ObjectName": "RegistryKey",
         },
     },
     generic_mappings={
         "EventType": "ActionType",
         "User": "InitiatingProcessAccountName",
+        "ComputerName": "DeviceName",
         "CommandLine": "InitiatingProcessCommandLine",
         "Image": "InitiatingProcessFolderPath",
         "ProcessName": "InitiatingProcessFolderPath",

--- a/sigma/pipelines/sentinelasim/sentinelasim.py
+++ b/sigma/pipelines/sentinelasim/sentinelasim.py
@@ -14,6 +14,7 @@ from sigma.processing.transformations import (
     DropDetectionItemTransformation,
     ReplaceStringTransformation,
     RuleFailureTransformation,
+    SetStateTransformation,
 )
 
 from ..kusto_common.errors import InvalidFieldTransformation
@@ -224,6 +225,10 @@ def sentinel_asim_pipeline(
     """
 
     pipeline_items = [
+        ProcessingItem(
+            identifier="sentinel_asim_set_timestamp_field",
+            transformation=SetStateTransformation(key="timestamp_field", val="TimeGenerated"),
+        ),
         ProcessingItem(
             identifier="sentinel_asim_set_query_table",
             transformation=SetQueryTableStateTransformation(

--- a/tests/test_pipelines_microsoftxdr.py
+++ b/tests/test_pipelines_microsoftxdr.py
@@ -1131,7 +1131,7 @@ correlation:
     assert "DeviceProcessEvents" in query
     assert 'ProcessCommandLine =~ "whoami"' in query
     assert "summarize ValueCount = count_distinct(AccountName)" in query
-    assert "bin(TimeGenerated, 5m)" in query
+    assert "bin(Timestamp, 5m)" in query
     assert "| where ValueCount >= 10" in query
 
 
@@ -1168,7 +1168,7 @@ correlation:
     query = result[0]
     assert "DeviceProcessEvents" in query
     assert "summarize ValueAvg = avg(AccountName)" in query
-    assert "bin(TimeGenerated, 10m)" in query
+    assert "bin(Timestamp, 10m)" in query
     assert "| where ValueAvg >= 5" in query
 
 
@@ -1205,7 +1205,7 @@ correlation:
     query = result[0]
     assert "DeviceProcessEvents" in query
     assert "summarize EventCount = count()" in query
-    assert "bin(TimeGenerated, 10m)" in query
+    assert "bin(Timestamp, 10m)" in query
     assert "| where EventCount >= 5" in query
 
 
@@ -1242,7 +1242,7 @@ correlation:
     query = result[0]
     assert "DeviceNetworkEvents" in query
     assert "summarize EventCount = count()" in query
-    assert "bin(TimeGenerated, 5m)" in query
+    assert "bin(Timestamp, 5m)" in query
     assert "| where EventCount >= 10" in query
 
 
@@ -1329,7 +1329,7 @@ correlation:
     assert "DeviceProcessEvents" in query
     assert "DeviceFileEvents" in query
     assert "summarize EventCount = count()" in query
-    assert "bin(TimeGenerated, 5m)" in query
+    assert "bin(Timestamp, 5m)" in query
     assert "| where EventCount >= 10" in query
 
 
@@ -1418,7 +1418,7 @@ correlation:
     assert 'ProcessCommandLine =~ "whoami"' in query
     assert 'FolderPath endswith ".exe"' in query
     assert "summarize ValueCount = count_distinct(AccountName)" in query
-    assert "bin(TimeGenerated, 5m)" in query
+    assert "bin(Timestamp, 5m)" in query
     assert "| where ValueCount >= 10" in query
 
 

--- a/tests/test_pipelines_microsoftxdr.py
+++ b/tests/test_pipelines_microsoftxdr.py
@@ -1549,3 +1549,105 @@ detection:
     assert "test.exe" in results[2]
     assert "DeviceProcessEvents" in results[3]
     assert "cmd.exe" in results[3]
+
+
+def test_microsoft_xdr_correlation_multi_rule_temporal():
+    """Multi-rule temporal correlation: each sub-query is tagged with its rule ID and
+    TemporalCount uses count_distinct(EventType) to detect distinct event types co-occurring."""
+    backend = KustoBackend(processing_pipeline=microsoft_xdr_pipeline())
+    yaml_rules = """
+title: Suspicious Connection
+name: susp_conn
+status: test
+logsource:
+    category: network_connection
+    product: windows
+detection:
+    sel:
+        DestinationPort: 4444
+    condition: sel
+---
+title: Suspicious Process
+name: susp_proc
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        Image|endswith: powershell.exe
+    condition: sel
+---
+title: Exploit Chain
+status: test
+correlation:
+    type: temporal
+    rules:
+        - susp_conn
+        - susp_proc
+    group-by:
+        - AccountName
+    timespan: 10s
+    condition:
+        gte: 2
+"""
+    result = backend.convert(SigmaCollection.from_yaml(yaml_rules))
+    assert len(result) == 1
+    query = result[0]
+    assert query.startswith("union")
+    assert "DeviceNetworkEvents" in query
+    assert "DeviceProcessEvents" in query
+    # Each sub-query must be tagged with its rule name
+    assert '| extend EventType = "susp_conn"' in query
+    assert '| extend EventType = "susp_proc"' in query
+    # Aggregation must count distinct event types, not total events
+    assert "summarize TemporalCount = count_distinct(EventType)" in query
+    assert "bin(Timestamp, 10s)" in query
+    assert ", AccountName" in query
+    assert "| where TemporalCount >= 2" in query
+
+
+def test_microsoft_xdr_correlation_temporal_without_groupby():
+    """Temporal correlation with no group-by clause."""
+    backend = KustoBackend(processing_pipeline=microsoft_xdr_pipeline())
+    yaml_rules = """
+title: Brute Force
+name: brute_force
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine|contains: failed
+    condition: sel
+---
+title: Successful Logon
+name: succ_logon
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine|contains: success
+    condition: sel
+---
+title: Brute Force Success
+status: test
+correlation:
+    type: temporal
+    rules:
+        - brute_force
+        - succ_logon
+    timespan: 5m
+    condition:
+        gte: 2
+"""
+    result = backend.convert(SigmaCollection.from_yaml(yaml_rules))
+    assert len(result) == 1
+    query = result[0]
+    assert "summarize TemporalCount = count_distinct(EventType) by bin(Timestamp, 5m)" in query
+    assert "| where TemporalCount >= 2" in query
+    # No trailing group-by fields
+    assert "AccountName" not in query

--- a/tests/test_pipelines_microsoftxdr.py
+++ b/tests/test_pipelines_microsoftxdr.py
@@ -1172,6 +1172,167 @@ correlation:
     assert "| where ValueAvg >= 5" in query
 
 
+def test_microsoft_xdr_correlation_single_rule_event_count():
+    """Single-rule event_count correlation."""
+    backend = KustoBackend(processing_pipeline=microsoft_xdr_pipeline())
+    yaml_rules = """
+title: Suspicious Process
+name: susp_process
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: mimikatz
+    condition: sel
+---
+title: High Event Count
+status: test
+correlation:
+    type: event_count
+    rules:
+        - susp_process
+    group-by:
+        - AccountName
+    timespan: 10m
+    condition:
+        gte: 5
+        field: AccountName
+"""
+    result = backend.convert(SigmaCollection.from_yaml(yaml_rules))
+    assert len(result) == 1
+    query = result[0]
+    assert "DeviceProcessEvents" in query
+    assert "summarize EventCount = count()" in query
+    assert "bin(TimeGenerated, 10m)" in query
+    assert "| where EventCount >= 5" in query
+
+
+def test_microsoft_xdr_correlation_event_count_different_table():
+    """event_count correlation where base rule targets DeviceNetworkEvents."""
+    backend = KustoBackend(processing_pipeline=microsoft_xdr_pipeline())
+    yaml_rules = """
+title: Suspicious Connection
+name: susp_conn
+status: test
+logsource:
+    category: network_connection
+    product: windows
+detection:
+    sel:
+        DestinationPort: 4444
+    condition: sel
+---
+title: Many Connections
+status: test
+correlation:
+    type: event_count
+    rules:
+        - susp_conn
+    group-by:
+        - AccountName
+    timespan: 5m
+    condition:
+        gte: 10
+        field: AccountName
+"""
+    result = backend.convert(SigmaCollection.from_yaml(yaml_rules))
+    assert len(result) == 1
+    query = result[0]
+    assert "DeviceNetworkEvents" in query
+    assert "summarize EventCount = count()" in query
+    assert "bin(TimeGenerated, 5m)" in query
+    assert "| where EventCount >= 10" in query
+
+
+def test_microsoft_xdr_correlation_event_count_lte_operator():
+    """event_count correlation using a lte threshold operator."""
+    backend = KustoBackend(processing_pipeline=microsoft_xdr_pipeline())
+    yaml_rules = """
+title: Suspicious Process
+name: susp_process
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: mimikatz
+    condition: sel
+---
+title: Low Event Count
+status: test
+correlation:
+    type: event_count
+    rules:
+        - susp_process
+    group-by:
+        - AccountName
+    timespan: 10m
+    condition:
+        lte: 3
+        field: AccountName
+"""
+    result = backend.convert(SigmaCollection.from_yaml(yaml_rules))
+    assert len(result) == 1
+    query = result[0]
+    assert "DeviceProcessEvents" in query
+    assert "summarize EventCount = count()" in query
+    assert "| where EventCount <= 3" in query
+
+
+def test_microsoft_xdr_correlation_multi_rule_event_count():
+    """Multi-rule event_count correlation: sub-queries are unioned."""
+    backend = KustoBackend(processing_pipeline=microsoft_xdr_pipeline())
+    yaml_rules = """
+title: Suspicious Process
+name: susp_process
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: whoami
+    condition: sel
+---
+title: Suspicious File
+name: susp_file
+status: test
+logsource:
+    category: file_event
+    product: windows
+detection:
+    sel:
+        TargetFilename|endswith: .exe
+    condition: sel
+---
+title: Combined Event Count
+status: test
+correlation:
+    type: event_count
+    rules:
+        - susp_process
+        - susp_file
+    group-by:
+        - AccountName
+    timespan: 5m
+    condition:
+        gte: 10
+        field: AccountName
+"""
+    result = backend.convert(SigmaCollection.from_yaml(yaml_rules))
+    assert len(result) == 1
+    query = result[0]
+    assert query.startswith("union")
+    assert "DeviceProcessEvents" in query
+    assert "DeviceFileEvents" in query
+    assert "summarize EventCount = count()" in query
+    assert "bin(TimeGenerated, 5m)" in query
+    assert "| where EventCount >= 10" in query
+
+
 def test_microsoft_xdr_correlation_single_rule_table_from_network_connection():
     """Single-rule correlation where base rule targets DeviceNetworkEvents."""
     backend = KustoBackend(processing_pipeline=microsoft_xdr_pipeline())

--- a/tests/test_pipelines_microsoftxdr.py
+++ b/tests/test_pipelines_microsoftxdr.py
@@ -1651,3 +1651,124 @@ correlation:
     assert "| where TemporalCount >= 2" in query
     # No trailing group-by fields
     assert "AccountName" not in query
+
+
+def test_microsoft_xdr_correlation_temporal_ordered():
+    """Multi-rule temporal_ordered correlation: events must appear in declared order within the window."""
+    backend = KustoBackend(processing_pipeline=microsoft_xdr_pipeline())
+    yaml_rules = """
+title: Failed Logon
+name: failed_logon
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine|contains: failed_logon
+    condition: sel
+---
+title: Successful Logon
+name: succ_logon
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine|contains: successful_logon
+    condition: sel
+---
+title: Suspicious Process
+name: susp_proc
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        Image|endswith: cmd.exe
+    condition: sel
+---
+title: Brute Force Then Execute
+status: test
+correlation:
+    type: temporal_ordered
+    rules:
+        - failed_logon
+        - succ_logon
+        - susp_proc
+    group-by:
+        - AccountName
+    timespan: 10m
+    condition:
+        gte: 3
+"""
+    result = backend.convert(SigmaCollection.from_yaml(yaml_rules))
+    assert len(result) == 1
+    query = result[0]
+    assert query.startswith("union")
+    # Each sub-query tagged with both EventType and EventOrder
+    assert '| extend EventType = "failed_logon", EventOrder = 1' in query
+    assert '| extend EventType = "succ_logon", EventOrder = 2' in query
+    assert '| extend EventType = "susp_proc", EventOrder = 3' in query
+    # Aggregation captures first occurrence per event type
+    assert "summarize TemporalCount = count_distinct(EventType)" in query
+    assert "FirstTs1 = minif(Timestamp, EventOrder == 1)" in query
+    assert "FirstTs2 = minif(Timestamp, EventOrder == 2)" in query
+    assert "FirstTs3 = minif(Timestamp, EventOrder == 3)" in query
+    assert "bin(Timestamp, 10m)" in query
+    assert ", AccountName" in query
+    # Ordering constraints must be present
+    assert "| where TemporalCount >= 3 and FirstTs1 < FirstTs2 and FirstTs2 < FirstTs3" in query
+
+
+def test_microsoft_xdr_correlation_temporal_ordered_two_rules():
+    """temporal_ordered with exactly two rules: one ordering constraint."""
+    backend = KustoBackend(processing_pipeline=microsoft_xdr_pipeline())
+    yaml_rules = """
+title: Network Recon
+name: net_recon
+status: test
+logsource:
+    category: network_connection
+    product: windows
+detection:
+    sel:
+        DestinationPort: 445
+    condition: sel
+---
+title: Lateral Move
+name: lateral_move
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        Image|endswith: psexec.exe
+    condition: sel
+---
+title: Recon Then Lateral Movement
+status: test
+correlation:
+    type: temporal_ordered
+    rules:
+        - net_recon
+        - lateral_move
+    timespan: 5m
+    condition:
+        gte: 2
+"""
+    result = backend.convert(SigmaCollection.from_yaml(yaml_rules))
+    assert len(result) == 1
+    query = result[0]
+    assert "DeviceNetworkEvents" in query
+    assert "DeviceProcessEvents" in query
+    assert '| extend EventType = "net_recon", EventOrder = 1' in query
+    assert '| extend EventType = "lateral_move", EventOrder = 2' in query
+    assert "FirstTs1 = minif(Timestamp, EventOrder == 1)" in query
+    assert "FirstTs2 = minif(Timestamp, EventOrder == 2)" in query
+    # Single ordering constraint with no group-by
+    assert "| where TemporalCount >= 2 and FirstTs1 < FirstTs2" in query
+    assert "FirstTs2 < FirstTs3" not in query

--- a/tests/test_pipelines_microsoftxdr.py
+++ b/tests/test_pipelines_microsoftxdr.py
@@ -1093,6 +1093,237 @@ def test_microsoft_xdr_postprocessing_factory_pattern():
     assert item1.transformation is not item2.transformation
 
 
+# ─── Correlation rule tests ───────────────────────────────────────────────────
+
+
+def test_microsoft_xdr_correlation_single_rule_value_count():
+    """Single-rule value_count correlation: table is prepended by postprocessing."""
+    backend = KustoBackend(processing_pipeline=microsoft_xdr_pipeline())
+    yaml_rules = """
+title: Suspicious Process
+name: susp_process
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: whoami
+    condition: sel
+---
+title: Multiple Suspicious Processes
+status: test
+correlation:
+    type: value_count
+    rules:
+        - susp_process
+    group-by:
+        - AccountName
+    timespan: 5m
+    condition:
+        gte: 10
+        field: AccountName
+"""
+    result = backend.convert(SigmaCollection.from_yaml(yaml_rules))
+    # Only the correlation query is returned (base rule is consumed)
+    assert len(result) == 1
+    query = result[0]
+    assert "DeviceProcessEvents" in query
+    assert 'ProcessCommandLine =~ "whoami"' in query
+    assert "summarize ValueCount = count_distinct(AccountName)" in query
+    assert "bin(TimeGenerated, 5m)" in query
+    assert "| where ValueCount >= 10" in query
+
+
+def test_microsoft_xdr_correlation_single_rule_value_avg():
+    """Single-rule value_avg correlation."""
+    backend = KustoBackend(processing_pipeline=microsoft_xdr_pipeline())
+    yaml_rules = """
+title: Suspicious Process
+name: susp_process
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: mimikatz
+    condition: sel
+---
+title: High Avg
+status: test
+correlation:
+    type: value_avg
+    rules:
+        - susp_process
+    group-by:
+        - AccountName
+    timespan: 10m
+    condition:
+        gte: 5
+        field: AccountName
+"""
+    result = backend.convert(SigmaCollection.from_yaml(yaml_rules))
+    assert len(result) == 1
+    query = result[0]
+    assert "DeviceProcessEvents" in query
+    assert "summarize ValueAvg = avg(AccountName)" in query
+    assert "bin(TimeGenerated, 10m)" in query
+    assert "| where ValueAvg >= 5" in query
+
+
+def test_microsoft_xdr_correlation_single_rule_table_from_network_connection():
+    """Single-rule correlation where base rule targets DeviceNetworkEvents."""
+    backend = KustoBackend(processing_pipeline=microsoft_xdr_pipeline())
+    yaml_rules = """
+title: Suspicious Connection
+name: susp_conn
+status: test
+logsource:
+    category: network_connection
+    product: windows
+detection:
+    sel:
+        DestinationPort: 4444
+    condition: sel
+---
+title: Many Connections
+status: test
+correlation:
+    type: value_count
+    rules:
+        - susp_conn
+    group-by:
+        - AccountName
+    timespan: 5m
+    condition:
+        gte: 5
+        field: AccountName
+"""
+    result = backend.convert(SigmaCollection.from_yaml(yaml_rules))
+    assert len(result) == 1
+    query = result[0]
+    assert "DeviceNetworkEvents" in query
+    assert "summarize ValueCount" in query
+
+
+def test_microsoft_xdr_correlation_multi_rule_value_count():
+    """Multi-rule value_count correlation: each sub-query gets its own table prefix,
+    and the result is a union without a top-level table prefix."""
+    backend = KustoBackend(processing_pipeline=microsoft_xdr_pipeline())
+    yaml_rules = """
+title: Suspicious Process
+name: susp_process
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: whoami
+    condition: sel
+---
+title: Suspicious File
+name: susp_file
+status: test
+logsource:
+    category: file_event
+    product: windows
+detection:
+    sel:
+        TargetFilename|endswith: .exe
+    condition: sel
+---
+title: Combined Suspicious Activity
+status: test
+correlation:
+    type: value_count
+    rules:
+        - susp_process
+        - susp_file
+    group-by:
+        - AccountName
+    timespan: 5m
+    condition:
+        gte: 10
+        field: AccountName
+"""
+    result = backend.convert(SigmaCollection.from_yaml(yaml_rules))
+    assert len(result) == 1
+    query = result[0]
+    assert query.startswith("union")
+    assert "DeviceProcessEvents" in query
+    assert "DeviceFileEvents" in query
+    assert 'ProcessCommandLine =~ "whoami"' in query
+    assert 'FolderPath endswith ".exe"' in query
+    assert "summarize ValueCount = count_distinct(AccountName)" in query
+    assert "bin(TimeGenerated, 5m)" in query
+    assert "| where ValueCount >= 10" in query
+
+
+def test_microsoft_xdr_correlation_multi_rule_three_tables():
+    """Multi-rule correlation spanning three different tables."""
+    backend = KustoBackend(processing_pipeline=microsoft_xdr_pipeline())
+    yaml_rules = """
+title: Suspicious Process
+name: susp_process
+status: test
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    sel:
+        CommandLine: whoami
+    condition: sel
+---
+title: Suspicious File
+name: susp_file
+status: test
+logsource:
+    category: file_event
+    product: windows
+detection:
+    sel:
+        TargetFilename|endswith: .ps1
+    condition: sel
+---
+title: Suspicious Connection
+name: susp_conn
+status: test
+logsource:
+    category: network_connection
+    product: windows
+detection:
+    sel:
+        DestinationPort: 4444
+    condition: sel
+---
+title: Multi-table Correlation
+status: test
+correlation:
+    type: value_count
+    rules:
+        - susp_process
+        - susp_file
+        - susp_conn
+    group-by:
+        - AccountName
+    timespan: 15m
+    condition:
+        gte: 3
+        field: AccountName
+"""
+    result = backend.convert(SigmaCollection.from_yaml(yaml_rules))
+    assert len(result) == 1
+    query = result[0]
+    assert query.startswith("union")
+    assert "DeviceProcessEvents" in query
+    assert "DeviceFileEvents" in query
+    assert "DeviceNetworkEvents" in query
+    assert "summarize ValueCount" in query
+    assert "| where ValueCount >= 3" in query
+
+
 def test_microsoft_xdr_pipeline_reuse_state_reset():
     """
     Test that pipeline state resets correctly across multiple rule conversions.


### PR DESCRIPTION
Hello,

This PR adds support for all  [Sigma Correlation rule type ](https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-correlation-rules-specification.md#correlation-types) the implementation follows the conventions established in [pysigma](https://github.com/SigmaHQ/pySigma) and aligns as closely as possible with the correlation support design planned there.

All 120 existing tests continue to pass (88.82% coverage, above the 80% threshold), and 13 new correlation-specific tests have been added. I focused on microsoft_xdr as it was the only noted as production ready

## Changes

### `sigma/backends/kusto/kusto.py`
Implemented all 8 Sigma correlation rule types by overriding the relevant `convert_correlation_*_rule` methods:

| Correlation type | KQL aggregation |
|---|---|
| `event_count` | `summarize EventCount = count() by bin(<timestamp>, <timespan>)` |
| `value_count` | `summarize ValueCount = count_distinct(<field>) by bin(<timestamp>, <timespan>)` |
| `value_avg` | `summarize ValueAvg = avg(<field>) by bin(<timestamp>, <timespan>)` |
| `value_median` | `summarize ValueMedian = percentile(<field>, 50) by bin(<timestamp>, <timespan>)` |
| `value_sum` | `summarize ValueSum = sum(<field>) by bin(<timestamp>, <timespan>)` |
| `value_percentile` | `summarize ValuePercentile = percentile(<field>, <p>) by bin(<timestamp>, <timespan>)` |
| `temporal` | `summarize TemporalCount = count_distinct(EventType) by bin(<timestamp>, <timespan>)` |
| `temporal_ordered` | `summarize TemporalCount = count_distinct(EventType), <order_aggs> by bin(<timestamp>, <timespan>)` |

Multi-rule correlations union all referenced sub-queries with `union (…), (…)`.

Added `_correlation_timespan_to_kql()` to map Sigma timespan units (`s/m/h/d`) to KQL equivalents (`s/min/h/d`).

Added `_get_timestamp_field()` which reads `pipeline.state["timestamp_field"]` and falls back to `"Timestamp"`.

### `sigma/pipelines/kusto_common/transformations.py`
- Extended `SetQueryTableStateTransformation.apply()` to handle `SigmaCorrelationRule` (derives the table from the first matching referenced base rule).
- Extended `PrependQueryTableTransformation` to skip the table-prepend for multi-rule correlations (each sub-query already embeds its own table).

### `sigma/pipelines/kusto_common/conditions.py` / `postprocessing.py`
- Minor fixes for correlation-rule compatibility.

### `sigma/pipelines/azuremonitor/azuremonitor.py`
- Adds `SetStateTransformation(key="timestamp_field", val="TimeGenerated")` so correlation rules in Azure Monitor pipelines use the correct field automatically.

### `sigma/pipelines/sentinelasim/sentinelasim.py`
- Same as above for the Sentinel ASIM pipeline.

### `sigma/pipelines/microsoftxdr/mappings.py`
- Added `ComputerName → DeviceName` mapping for all relevant tables.
- Added `group_by` field normalization support for custom pipelines.

### `tests/test_pipelines_microsoftxdr.py` (+615 lines)
New correlation tests covering:
- `value_count`, `value_avg`, `event_count` (single-rule)
- `event_count` with different tables, LTE operator, multi-rule
- `value_count` multi-rule, three-table union
- `temporal` (with and without `group_by`)
- `temporal_ordered` (single and two-rule variants)

### `README.md`
- Added correlation rule support table
- Added "Custom Timestamp Field" section documenting per-pipeline defaults and custom YAML override via `set_state`

---

## Custom Timestamp Field (backward-compatible)

The timestamp field used in `bin()` is now configurable via pipeline state:

```yaml
transformations:
  - id: set_timestamp_field
    type: set_state
    key: timestamp_field
    val: "TimeGenerated"